### PR TITLE
clear everything

### DIFF
--- a/couchie.js
+++ b/couchie.js
@@ -14,6 +14,7 @@
       for (i in this.revs()) {
         localStorage.removeItem(this.n+i)
       }
+      localStorage.removeItem(this.n+'_revs')
       setTimeout(cb, 0)
     } else {
       setTimeout(cb, 0)


### PR DESCRIPTION
without this you get back [null,null,null,null] etc when you do a .clear followed by a .all
